### PR TITLE
Remove unnecessary 'direct' word from documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/log-lazy/issues/2
-Your prepared branch: issue-2-c99f5d89
-Your prepared working directory: /tmp/gh-issue-solver-1758433057025
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/log-lazy/issues/2
+Your prepared branch: issue-2-c99f5d89
+Your prepared working directory: /tmp/gh-issue-solver-1758433057025
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ deno add npm:log-lazy
 ```javascript
 import makeLog from 'log-lazy';
 
-const log = makeLog({ level: 'info' }); // ✨ Direct, simple, efficient!
+const log = makeLog({ level: 'info' }); // ✨ Simple, efficient!
 
-// Preferred: Use log() directly (defaults to info level)
+// Preferred: Use log() (defaults to info level)
 log('Server started');
 log(() => `User ${user.id} logged in`); // With lazy evaluation
 
@@ -46,7 +46,7 @@ log.debug(() => `Debug data: ${JSON.stringify(largeObject)}`); // Not evaluated!
 log(() => `Processing ${items.length} items`); // Evaluated and logged at info level
 ```
 
-**That's it!** Simple, direct, and efficient!
+**That's it!** Simple and efficient!
 
 ## 🎯 The Problem This Solves
 
@@ -73,7 +73,7 @@ log.info(`Processing order #${order.id} with ${order.items.length} items totalin
 ### ✅ Lazy Logging (Only Evaluates When Needed)
 ```javascript
 import makeLog from 'log-lazy';
-const log = makeLog({ level: 'info' }); // Direct and simple!
+const log = makeLog({ level: 'info' }); // Simple!
 
 // Preferred: Use log() for info-level logging
 log(() => `Processing order #${order.id} with ${order.items.length} items totaling $${order.calculateTotal()}`);
@@ -153,10 +153,10 @@ const devLog = makeLog({ level: 'development' });  // fatal, error, warn, info, 
 ```javascript
 import makeLog from 'log-lazy';
 
-// Create log directly - clean and simple!
+// Create log - clean and simple!
 const log = makeLog({ level: 'info' }); // ✨ That's it!
 
-// Preferred: Use log() directly (defaults to info level)
+// Preferred: Use log() (defaults to info level)
 log(() => `Server started on port ${port}`);
 log(() => `Processing request: ${JSON.stringify(request)}`);
 
@@ -164,7 +164,7 @@ log(() => `Processing request: ${JSON.stringify(request)}`);
 log.error(() => `Failed to connect: ${error.message}`);
 log.debug(() => `State: ${JSON.stringify(state)}`); // Zero cost when disabled!
 
-// Clean, direct API with zero overhead! 🎯
+// Clean API with zero overhead! 🎯
 ```
 
 ### Lazy Evaluation Examples
@@ -327,7 +327,7 @@ class OrderService {
   constructor() {
     this.log = makeLog({ 
       level: process.env.LOG_LEVEL || 'info' 
-    }); // Direct and clean!
+    }); // Clean and simple!
   }
 
   async createOrder(orderData) {

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This directory contains examples demonstrating the key features of log-lazy.
 The main showcase example demonstrating lazy evaluation with template strings. Shows how to use `log()` and `log.error()` with zero performance cost in production.
 
 ### ⚡ [comparison.js](./comparison.js)
-Direct performance comparison between traditional logging and lazy logging, showing the 2500x speed improvement.
+Performance comparison between traditional logging and lazy logging, showing the 2500x speed improvement.
 
 ### 🔧 [complete.js](./complete.js)  
 Comprehensive example showing all log levels and how they behave in production mode.


### PR DESCRIPTION
## 🎯 Summary

This PR removes the word 'direct' from the documentation where it was being used as a filler word without adding meaningful context, making the documentation cleaner and more concise.

## 📋 Issue Reference
Fixes #3

## ✨ Key Changes

### Files Modified
- **README.md**: Removed 'direct' from 7 locations where it was used unnecessarily
- **examples/README.md**: Updated performance comparison description

### Specific Changes
1. Changed "Direct, simple, efficient!" to "Simple, efficient!"
2. Changed "Use log() directly" to "Use log()" 
3. Changed "Simple, direct, and efficient!" to "Simple and efficient!"
4. Changed "Direct and simple!" to "Simple!"
5. Changed "Create log directly" to "Create log"
6. Changed "Clean, direct API" to "Clean API"
7. Changed "Direct and clean!" to "Clean and simple!"
8. Changed "Direct performance comparison" to "Performance comparison"

### Preserved Uses
- Kept legitimate uses of "directory" in technical contexts (e.g., "This directory contains...")
- Maintained "working directory" in CLAUDE.md as it's a proper technical term

## 🔍 Verification

Searched all markdown files to ensure:
- ✅ All unnecessary uses of 'direct' as a filler word have been removed
- ✅ Legitimate technical uses of 'directory' are preserved
- ✅ Documentation remains clear and maintains its original meaning

---
*🤖 Generated with [Claude Code](https://claude.ai/code)*